### PR TITLE
chore: update Docusaurus packages to 3.9.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "tlsnotary",
       "version": "0.0.0",
       "dependencies": {
-        "@docusaurus/core": "^3.9.0",
-        "@docusaurus/plugin-client-redirects": "^3.9.0",
-        "@docusaurus/preset-classic": "^3.9.0",
+        "@docusaurus/core": "^3.9.2",
+        "@docusaurus/plugin-client-redirects": "^3.9.2",
+        "@docusaurus/preset-classic": "^3.9.2",
         "@docusaurus/theme-mermaid": "^3.9.2",
         "@mdx-js/react": "^3.1.1",
         "clsx": "^2.1.1",
@@ -21,9 +21,9 @@
         "remark-math": "^6.0.0"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "3.9.0",
-        "@docusaurus/tsconfig": "3.9.0",
-        "@docusaurus/types": "3.9.0",
+        "@docusaurus/module-type-aliases": "3.9.2",
+        "@docusaurus/tsconfig": "3.9.2",
+        "@docusaurus/types": "3.9.2",
         "typescript": "~5.9.2"
       },
       "engines": {
@@ -3466,42 +3466,6 @@
         }
       }
     },
-    "node_modules/@docusaurus/bundler/node_modules/@docusaurus/types": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
-      "integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/bundler/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/@docusaurus/core": {
       "version": "3.9.2",
       "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.9.2.tgz",
@@ -3631,13 +3595,12 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.9.0.tgz",
-      "integrity": "sha512-0ucYr79FpTCebN+l3ZlKqoW7HbMqSKT8JdsEg6QoUtxD3C7trF6KZiK/X6Yh+xekO1w3zzXYgPcIYTF2DV81tQ==",
-      "dev": true,
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.9.2.tgz",
+      "integrity": "sha512-8qVe2QA9hVLzvnxP46ysuofJUIc/yYQ82tvA/rBTrnpXtCjNSFLxEZfd5U8cYZuJIVlkPxamsIgwd5tGZXfvew==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/types": "3.9.0",
+        "@docusaurus/types": "3.9.2",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -3708,42 +3671,6 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/@docusaurus/types": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
-      "integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/@docusaurus/plugin-content-docs": {
       "version": "3.9.2",
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.9.2.tgz",
@@ -3778,61 +3705,6 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.9.2.tgz",
-      "integrity": "sha512-8qVe2QA9hVLzvnxP46ysuofJUIc/yYQ82tvA/rBTrnpXtCjNSFLxEZfd5U8cYZuJIVlkPxamsIgwd5tGZXfvew==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/types": "3.9.2",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "@types/react-router-dom": "*",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/types": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
-      "integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/@docusaurus/plugin-content-pages": {
       "version": "3.9.2",
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.9.2.tgz",
@@ -3856,42 +3728,6 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-content-pages/node_modules/@docusaurus/types": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
-      "integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-pages/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/@docusaurus/plugin-css-cascade-layers": {
       "version": "3.9.2",
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.9.2.tgz",
@@ -3906,42 +3742,6 @@
       },
       "engines": {
         "node": ">=20.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-css-cascade-layers/node_modules/@docusaurus/types": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
-      "integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-css-cascade-layers/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-debug": {
@@ -3965,42 +3765,6 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-debug/node_modules/@docusaurus/types": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
-      "integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-debug/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/@docusaurus/plugin-google-analytics": {
       "version": "3.9.2",
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.9.2.tgz",
@@ -4018,42 +3782,6 @@
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/@docusaurus/types": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
-      "integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
@@ -4076,42 +3804,6 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/types": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
-      "integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/@docusaurus/plugin-google-tag-manager": {
       "version": "3.9.2",
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.9.2.tgz",
@@ -4129,42 +3821,6 @@
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/@docusaurus/types": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
-      "integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
@@ -4191,42 +3847,6 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/types": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
-      "integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-sitemap/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/@docusaurus/plugin-svgr": {
       "version": "3.9.2",
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.9.2.tgz",
@@ -4248,42 +3868,6 @@
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-svgr/node_modules/@docusaurus/types": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
-      "integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-svgr/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/@docusaurus/preset-classic": {
@@ -4314,42 +3898,6 @@
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/types": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
-      "integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/@docusaurus/theme-classic": {
@@ -4392,61 +3940,6 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.9.2.tgz",
-      "integrity": "sha512-8qVe2QA9hVLzvnxP46ysuofJUIc/yYQ82tvA/rBTrnpXtCjNSFLxEZfd5U8cYZuJIVlkPxamsIgwd5tGZXfvew==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/types": "3.9.2",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "@types/react-router-dom": "*",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/types": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
-      "integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/@docusaurus/theme-common": {
       "version": "3.9.2",
       "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.9.2.tgz",
@@ -4475,61 +3968,6 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.9.2.tgz",
-      "integrity": "sha512-8qVe2QA9hVLzvnxP46ysuofJUIc/yYQ82tvA/rBTrnpXtCjNSFLxEZfd5U8cYZuJIVlkPxamsIgwd5tGZXfvew==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/types": "3.9.2",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "@types/react-router-dom": "*",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/types": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
-      "integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-common/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/@docusaurus/theme-mermaid": {
       "version": "3.9.2",
       "resolved": "https://registry.npmjs.org/@docusaurus/theme-mermaid/-/theme-mermaid-3.9.2.tgz",
@@ -4556,61 +3994,6 @@
         "@mermaid-js/layout-elk": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@docusaurus/theme-mermaid/node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.9.2.tgz",
-      "integrity": "sha512-8qVe2QA9hVLzvnxP46ysuofJUIc/yYQ82tvA/rBTrnpXtCjNSFLxEZfd5U8cYZuJIVlkPxamsIgwd5tGZXfvew==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/types": "3.9.2",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "@types/react-router-dom": "*",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/@docusaurus/theme-mermaid/node_modules/@docusaurus/types": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
-      "integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-mermaid/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
@@ -4658,17 +4041,16 @@
       }
     },
     "node_modules/@docusaurus/tsconfig": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/tsconfig/-/tsconfig-3.9.0.tgz",
-      "integrity": "sha512-DPD1NcEAqBov2e2Rgwy/oNuExbWzU/eGc+DEAxl8tttfQ+xxN6iFXNMCzBuMeAvMC8OwUO+i9mZHYFP95903DA==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/tsconfig/-/tsconfig-3.9.2.tgz",
+      "integrity": "sha512-j6/Fp4Rlpxsc632cnRnl5HpOWeb6ZKssDj6/XzzAzVGXXfm9Eptx3rxCC+fDzySn9fHTS+CWJjPineCR1bB5WQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@docusaurus/types": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.0.tgz",
-      "integrity": "sha512-0klJLhHFHqkYoxIVp1LD7dnU1ASRTfSX+HFDiELOdz+YQUkOSfuU5hDa46zD8bLxrYffCb8FtJI7Z6BWAmVodg==",
-      "dev": true,
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
+      "integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
       "license": "MIT",
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
@@ -4691,7 +4073,6 @@
       "version": "5.10.0",
       "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
       "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "clone-deep": "^4.0.1",
@@ -4747,42 +4128,6 @@
         "node": ">=20.0"
       }
     },
-    "node_modules/@docusaurus/utils-common/node_modules/@docusaurus/types": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
-      "integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/utils-common/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/@docusaurus/utils-validation": {
       "version": "3.9.2",
       "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.9.2.tgz",
@@ -4800,42 +4145,6 @@
       },
       "engines": {
         "node": ">=20.0"
-      }
-    },
-    "node_modules/@docusaurus/utils/node_modules/@docusaurus/types": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
-      "integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/utils/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/@hapi/hoek": {

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@docusaurus/core": "^3.9.0",
-    "@docusaurus/plugin-client-redirects": "^3.9.0",
-    "@docusaurus/preset-classic": "^3.9.0",
+    "@docusaurus/core": "^3.9.2",
+    "@docusaurus/plugin-client-redirects": "^3.9.2",
+    "@docusaurus/preset-classic": "^3.9.2",
     "@docusaurus/theme-mermaid": "^3.9.2",
     "@mdx-js/react": "^3.1.1",
     "clsx": "^2.1.1",
@@ -28,9 +28,9 @@
     "remark-math": "^6.0.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.9.0",
-    "@docusaurus/tsconfig": "3.9.0",
-    "@docusaurus/types": "3.9.0",
+    "@docusaurus/module-type-aliases": "3.9.2",
+    "@docusaurus/tsconfig": "3.9.2",
+    "@docusaurus/types": "3.9.2",
     "typescript": "~5.9.2"
   },
   "browserslist": {


### PR DESCRIPTION
## Summary
- Update all Docusaurus packages from 3.9.0 to 3.9.2 (`@docusaurus/core`, `preset-classic`, `plugin-client-redirects`, `module-type-aliases`, `tsconfig`, `types`)
- Production build verified successfully