### PR TITLE
fix: update repo references from landing-page to website

### DIFF
--- a/docs/protocol/commit_strategy.md
+++ b/docs/protocol/commit_strategy.md
@@ -25,4 +25,4 @@ The commitment strategies differ mainly in the number of committed ranges (`K`).
 | `Attestation` | Artifact signed by the `Notary` attesting to the authenticity of the plaintext from a TLS session | Constant     | `Attestation` only contains data that remains constant-sized regardless of `K`, e.g., the Merkle root of the commitments |
 | `Secret`      | Artifact containing secret data that correspond to commitments in `Attestation`                   | Linear       | `Secret` contains some data whose sizes scale linearly with `K`, e.g., a Merkle tree whose number of leaves equals `K`   |
 
-Using the default hash algorithm (i.e., BLAKE3), every additional range committed costs around 250 bytes of increment in the size of `Secret`. For more details, please visit this [Jupyter notebook](https://github.com/tlsnotary/landing-page/blob/master/docs/protocol/commit_strategy.ipynb).
+Using the default hash algorithm (i.e., BLAKE3), every additional range committed costs around 250 bytes of increment in the size of `Secret`. For more details, please visit this [Jupyter notebook](https://github.com/tlsnotary/website/blob/master/docs/protocol/commit_strategy.ipynb).

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -57,7 +57,7 @@ const config: Config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/tlsnotary/landing-page',
+            'https://github.com/tlsnotary/website/edit/master/',
           // Enable math support in docs
           remarkPlugins: [remarkMath],
           rehypePlugins: [rehypeKatex],

--- a/src/components/ProjectList/index.tsx
+++ b/src/components/ProjectList/index.tsx
@@ -123,7 +123,7 @@ const ProjectList: React.FC = () => {
       {/* <div className={styles.actionCardContainer}>
         <ActionCard
           buttonText="Submit your project"
-          buttonUrl="https://github.com/tlsnotary/landing-page/issues/new?title=Add+a+Project+to+the+Projects+Showcase"
+          buttonUrl="https://github.com/tlsnotary/website/issues/new?title=Add+a+Project+to+the+Projects+Showcase"
           description="Submit your project to this page."
           title="Are we missing your project?"
         />


### PR DESCRIPTION
## Summary
- Fix `editUrl` in docusaurus config to point to `website` repo with correct `edit/master/` path (was causing 404s)
- Update Jupyter notebook link in `commit_strategy.md`
- Update project submission issue link in `ProjectList`