### PR TITLE
Add "More" link to blog sidebar

### DIFF
--- a/src/theme/BlogSidebar/Content/index.tsx
+++ b/src/theme/BlogSidebar/Content/index.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import Link from '@docusaurus/Link';
+import Content from '@theme-original/BlogSidebar/Content';
+import type ContentType from '@theme/BlogSidebar/Content';
+import type {WrapperProps} from '@docusaurus/types';
+
+type Props = WrapperProps<typeof ContentType>;
+
+export default function ContentWrapper(props: Props): JSX.Element {
+  return (
+    <>
+      <Content {...props} />
+      <Link to="/blog/archive" style={{display: 'inline-block', marginTop: '1.2rem', fontWeight: 600}}>
+        More →
+      </Link>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Readers reaching `/blog` only see the most recent posts in the left sidebar, with no visible path to older ones.
- Wraps `@theme/BlogSidebar/Content` (via Docusaurus swizzle, wrap mode) to append a **More →** link pointing at the auto-generated `/blog/archive` page.
- Wrapping `Content` covers both desktop and mobile sidebars in one small file — no Docusaurus internals copied, so upstream theme updates still flow through.